### PR TITLE
Add PR title and description generation for the Anthropic and OpenAI clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "gcmgen"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcmgen"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/anthropic.rs
+++ b/src/anthropic.rs
@@ -1,7 +1,7 @@
-use crate::client::CommitMessageGenerator;
+use crate::client::{CommitMessageGenerator, PullRequestGenerator};
 use crate::config::ServiceConfig;
 use reqwest::blocking::Client;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::error::Error;
 
 pub struct AnthropicClient {
@@ -17,6 +17,53 @@ impl AnthropicClient {
             model: service_config.model.clone(),
             client: Client::new(),
         }
+    }
+
+    fn generate_message(&self, messages: &Value) -> Result<String, Box<dyn Error>> {
+        let response = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_token)
+            .json(&json!({
+                "model": &self.model,
+                "messages": &messages,
+                "max_tokens": 1024,
+            }))
+            .send()?;
+
+        let response_json: Value = response.json()?;
+
+        response_json
+            .get("content")
+            .and_then(|content| content.get(0))
+            .and_then(|text| text.get("text"))
+            .and_then(|text| text.as_str())
+            .map(|text| text.to_string())
+            .ok_or_else(|| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "Failed to generate commit message. Unexpected response format: {}",
+                        response_json
+                    ),
+                )) as Box<dyn Error>
+            })
+    }
+}
+
+#[allow(dead_code)]
+impl PullRequestGenerator for AnthropicClient {
+    fn generate_pr_title(
+        &self,
+        _diff: &str,
+        _prefix: Option<&str>,
+    ) -> Result<String, Box<dyn Error>> {
+        todo!()
+    }
+
+    #[allow(dead_code)]
+    fn generate_pr_description(&self, _diff: &str) -> Result<String, Box<dyn Error>> {
+        todo!()
     }
 }
 
@@ -42,33 +89,7 @@ impl CommitMessageGenerator for AnthropicClient {
             }
         ]);
 
-        let response = self
-            .client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &self.api_token)
-            .json(&json!({
-                "model": &self.model,
-                "messages": &messages,
-                "max_tokens": 1024,
-            }))
-            .send()?;
-
-        let response_json: serde_json::Value = response.json()?;
-
-        let message = response_json
-            .get("content")
-            .and_then(|content| content.get(0))
-            .and_then(|text| text.get("text"))
-            .and_then(|text| text.as_str())
-            .ok_or_else(|| {
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Failed to generate commit message. Unexpected response format: {}",
-                        response_json
-                    ),
-                )) as Box<dyn Error>
-            })?;
+        let message = self.generate_message(&messages)?;
 
         let final_message = if let Some(prefix) = prefix {
             format!("{} {}", prefix, message.trim())

--- a/src/anthropic.rs
+++ b/src/anthropic.rs
@@ -56,7 +56,7 @@ impl PullRequestGenerator for AnthropicClient {
     fn generate_pr_title(
         &self,
         _diff: &str,
-        _prefix: Option<&str>,
+        _prefix: Option<&String>,
     ) -> Result<String, Box<dyn Error>> {
         todo!()
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::{command, Arg, ArgAction, ArgMatches};
+use clap::{command, crate_version, Arg, ArgAction, ArgMatches};
 
 pub fn build_cli() -> ArgMatches {
     command!()
-        .version("1.0")
+        .version(crate_version!())
         .author("Sebastian Stan")
         .about("Generates commit messages using AI")
         .arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,8 +23,14 @@ pub fn build_cli() -> ArgMatches {
                 .help("Set prefix for commit message. Example: gcmgen -p TICKET-123"),
         )
         .arg(
+            Arg::new("pr")
+                .long("pr")
+                .help("Opens up a new PR in the browser with generated description and title")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("list-services")
-                .long("list-services")
+                .long("ls")
                 .short('l')
                 .help("Lists all configured services")
                 .action(ArgAction::SetTrue),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ pub fn build_cli() -> ArgMatches {
                 .help("Set prefix for commit message. Example: gcmgen -p TICKET-123"),
         )
         .arg(
-            Arg::new("pr")
+            Arg::new("pull-request")
                 .long("pr")
                 .help("Opens up a new PR in the browser with generated description and title")
                 .action(ArgAction::SetTrue),
@@ -31,7 +31,6 @@ pub fn build_cli() -> ArgMatches {
         .arg(
             Arg::new("list-services")
                 .long("ls")
-                .short('l')
                 .help("Lists all configured services")
                 .action(ArgAction::SetTrue),
         )

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,36 @@ impl Client {
     }
 }
 
+pub trait PullRequestGenerator {
+    fn generate_pr_title(
+        &self,
+        diff: &str,
+        prefix: Option<&str>,
+    ) -> Result<String, Box<dyn std::error::Error>>;
+
+    fn generate_pr_description(&self, diff: &str) -> Result<String, Box<dyn std::error::Error>>;
+}
+
+impl PullRequestGenerator for Client {
+    fn generate_pr_title(
+        &self,
+        diff: &str,
+        prefix: Option<&str>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        match self {
+            Client::OpenAI(client) => client.generate_pr_title(diff, prefix),
+            Client::Anthropic(client) => client.generate_pr_title(diff, prefix),
+        }
+    }
+
+    fn generate_pr_description(&self, diff: &str) -> Result<String, Box<dyn std::error::Error>> {
+        match self {
+            Client::OpenAI(client) => client.generate_pr_description(diff),
+            Client::Anthropic(client) => client.generate_pr_description(diff),
+        }
+    }
+}
+
 pub trait CommitMessageGenerator {
     fn generate_commit_message(
         &self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,7 @@ pub trait PullRequestGenerator {
     fn generate_pr_title(
         &self,
         diff: &str,
-        prefix: Option<&str>,
+        prefix: Option<&String>,
     ) -> Result<String, Box<dyn std::error::Error>>;
 
     fn generate_pr_description(&self, diff: &str) -> Result<String, Box<dyn std::error::Error>>;
@@ -37,7 +37,7 @@ impl PullRequestGenerator for Client {
     fn generate_pr_title(
         &self,
         diff: &str,
-        prefix: Option<&str>,
+        prefix: Option<&String>,
     ) -> Result<String, Box<dyn std::error::Error>> {
         match self {
             Client::OpenAI(client) => client.generate_pr_title(diff, prefix),

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::process::Command;
 
 #[allow(dead_code)]
-fn create_pull_request(
+pub fn create_pull_request(
     title: &str,
     description: &str,
     base_branch: Option<&str>,

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,0 +1,37 @@
+use std::error::Error;
+use std::process::Command;
+
+#[allow(dead_code)]
+fn create_pull_request(
+    title: &str,
+    description: &str,
+    base_branch: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let mut command = Command::new("gh");
+
+    command.args([
+        "pr",
+        "create",
+        "--title",
+        title,
+        "--body",
+        description,
+        "--web",
+    ]);
+
+    if let Some(branch) = base_branch {
+        command.arg("--base").arg(branch);
+    }
+
+    let status = command.status()?;
+
+    if status.success() {
+        println!("Pull request creation page opened in your browser.");
+        Ok(())
+    } else {
+        Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to create pull request",
+        )))
+    }
+}

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -7,6 +7,8 @@ fn create_pull_request(
     description: &str,
     base_branch: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
+    let branch = base_branch.unwrap_or("main"); // main is default
+
     let mut command = Command::new("gh");
 
     command.args([
@@ -16,12 +18,10 @@ fn create_pull_request(
         title,
         "--body",
         description,
+        "--base",
+        branch,
         "--web",
     ]);
-
-    if let Some(branch) = base_branch {
-        command.arg("--base").arg(branch);
-    }
 
     let status = command.status()?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -44,6 +44,25 @@ pub fn get_diff() -> Result<String, GitError> {
     }
 }
 
+#[allow(dead_code)]
+pub fn get_branch_diff(base_branch: Option<&str>) -> Result<String, GitError> {
+    let branch = base_branch.unwrap_or("main"); // defaults to main
+    let output = Command::new("git").args(["diff", branch]).output()?;
+
+    if output.status.success() {
+        if output.stdout.is_empty() {
+            Err(GitError::EmptyDiff)
+        } else {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+    } else {
+        Err(GitCommandFailed(format!(
+            "Failed to get diff against branch '{}'",
+            branch
+        )))
+    }
+}
+
 pub fn commit(message: &str) -> Result<(), GitError> {
     let output = Command::new("git")
         .args(["commit", "-m", message])

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod anthropic;
 mod cli;
 mod client;
 mod config;
+mod gh;
 mod git;
 mod openai;
 mod vim;

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(service) = matches.get_one::<String>("set-default") {
         match config.set_default_service(service) {
-            Ok(_) => println!("Default service set to '{}'.", service),
+            Ok(_) => {
+                println!("Default service set to '{}'.", service);
+                return Ok(());
+            }
             Err(e) => {
                 eprintln!("Error setting default service: {}", e);
                 exit(1);
@@ -110,7 +113,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        // Generate the commit message
         let mut commit_message = client.generate_commit_message(&diff, prefix)?;
 
         // Display the generated commit message to the user

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let prefix = matches.get_one::<String>("prefix");
 
+    if matches.get_flag("pull-request") {
+        loop {
+            // Get the diff from Git
+            let branch_diff = match git::get_branch_diff(Some("main")) {
+                Ok(branch_diff) => branch_diff,
+                Err(GitError::EmptyDiff) => {
+                    eprintln!("Error: {}", GitError::EmptyDiff);
+                    return Ok(()); // Not an actual error, just exit gracefully
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    return Err(Box::new(e));
+                }
+            };
+            let title = client.generate_pr_title(&branch_diff, prefix)?;
+            let description = client.generate_pr_description(&branch_diff)?;
+
+            println!("\nGenerated PR Title:\n{}\n", title);
+            println!("Generated PR Description:\n{}\n", description);
+
+            // Ask the user what they want to do
+            print!("Do you want to (a)ccept, (r)egenerate, or (c)ancel? [a/e/c]: ");
+            io::stdout().flush()?;
+
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            let input = input.trim().to_lowercase();
+
+            match input.as_str() {
+                "a" | "A" => {
+                    // Open the PR in the web browser with the title and description
+                    create_pull_request(&title, &description, Some("main"))?;
+                    println!("Pull request created successfully.");
+                    return Ok(());
+                }
+                "r" | "R" => {
+                    println!("Regenerating commit message...");
+                }
+                "c" => {
+                    // Cancel the PR creation process
+                    println!("PR creation canceled.");
+                    return Ok(());
+                }
+                _ => {
+                    // Invalid input, ask again
+                    println!("Invalid option. Please choose 'a' to accept, 'e' to edit, or 'c' to cancel.");
+                }
+            }
+        }
+    }
+
     loop {
         // Get the diff from Git
         let diff = match git::get_diff() {
@@ -113,40 +164,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Err(Box::new(e));
             }
         };
-
-        if matches.get_flag("pull-request") {
-            let title = client.generate_pr_title(&diff, prefix)?;
-            let description = client.generate_pr_description(&diff)?;
-
-            println!("\nGenerated PR Title:\n{}\n", title);
-            println!("Generated PR Description:\n{}\n", description);
-
-            // Ask the user what they want to do
-            print!("Do you want to (a)ccept, (e)dit title/description, or (c)ancel? [a/e/c]: ");
-            io::stdout().flush()?;
-
-            let mut input = String::new();
-            io::stdin().read_line(&mut input)?;
-            let input = input.trim().to_lowercase();
-
-            match input.as_str() {
-                "a" => {
-                    // Open the PR in the web browser with the title and description
-                    create_pull_request(&title, &description, Some("main"))?;
-                    println!("Pull request created successfully.");
-                    return Ok(());
-                }
-                "c" => {
-                    // Cancel the PR creation process
-                    println!("PR creation canceled.");
-                    return Ok(());
-                }
-                _ => {
-                    // Invalid input, ask again
-                    println!("Invalid option. Please choose 'a' to accept, 'e' to edit, or 'c' to cancel.");
-                }
-            }
-        }
 
         let mut commit_message = client.generate_commit_message(&diff, prefix)?;
 

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -102,8 +102,6 @@ impl PullRequestGenerator for OpenAIClient {
 
         let description = self.generate_text(messages)?;
 
-        println!("{}", description);
-
         Ok(description.trim().to_string())
     }
 }

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -56,7 +56,7 @@ impl PullRequestGenerator for OpenAIClient {
     fn generate_pr_title(
         &self,
         diff: &str,
-        prefix: Option<&str>,
+        prefix: Option<&String>,
     ) -> Result<String, Box<dyn Error>> {
         let messages = json!([
             {
@@ -95,11 +95,14 @@ impl PullRequestGenerator for OpenAIClient {
             },
             {
                 "role": "assistant",
-                "content": "Generate a detailed and meaningful description for a GitHub pull request based on the provided git diff."
+                "content": "Generate a detailed and meaningful description for a GitHub pull request based on the provided git diff. \n\
+                Only answer with the description, nothing else."
             }
         ]);
 
         let description = self.generate_text(messages)?;
+
+        println!("{}", description);
 
         Ok(description.trim().to_string())
     }

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -27,11 +27,12 @@ impl OpenAIClient {
             .json(&json!({
                 "model": &self.model,
                 "messages": messages,
-                "max_tokens": 60,
+                "max_tokens": 500,
             }))
             .send()?;
 
         let response_json: Value = response.json()?;
+        println!("{}", response_json);
 
         response_json
             .get("choices")
@@ -96,7 +97,8 @@ impl PullRequestGenerator for OpenAIClient {
             {
                 "role": "assistant",
                 "content": "Generate a detailed and meaningful description for a GitHub pull request based on the provided git diff. \n\
-                Only answer with the description, nothing else."
+                Only answer with the description, nothing else. The description will be read by engineers, so keep it concise and meaningful.\
+                Don't bloat it. Keep the response under 500 tokens."
             }
         ]);
 

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -32,7 +32,6 @@ impl OpenAIClient {
             .send()?;
 
         let response_json: Value = response.json()?;
-        println!("{}", response_json);
 
         response_json
             .get("choices")

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -1,7 +1,7 @@
-use crate::client::CommitMessageGenerator;
+use crate::client::{CommitMessageGenerator, PullRequestGenerator};
 use crate::config::ServiceConfig;
 use reqwest::blocking::Client;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::error::Error;
 
 pub struct OpenAIClient {
@@ -17,6 +17,91 @@ impl OpenAIClient {
             model: service_config.model.clone(),
             client: Client::new(),
         }
+    }
+
+    pub fn generate_text(&self, messages: Value) -> Result<String, Box<dyn Error>> {
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/chat/completions")
+            .bearer_auth(&self.api_key)
+            .json(&json!({
+                "model": &self.model,
+                "messages": messages,
+                "max_tokens": 60,
+            }))
+            .send()?;
+
+        let response_json: Value = response.json()?;
+
+        response_json
+            .get("choices")
+            .and_then(|choices| choices.get(0))
+            .and_then(|choice| choice.get("message"))
+            .and_then(|content| content.get("content"))
+            .and_then(|text| text.as_str())
+            .map(|text| text.to_string())
+            .ok_or_else(|| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "Failed to generate PR title. Unexpected response format: {}",
+                        response_json
+                    ),
+                )) as Box<dyn Error>
+            })
+    }
+}
+
+impl PullRequestGenerator for OpenAIClient {
+    fn generate_pr_title(
+        &self,
+        diff: &str,
+        prefix: Option<&str>,
+    ) -> Result<String, Box<dyn Error>> {
+        let messages = json!([
+            {
+                "role": "system",
+                "content": "You are a helpful assistant specialized in writing concise GitHub pull request titles."
+            },
+            {
+                "role": "user",
+                "content": format!("Here is a git diff:\n\n{}", diff)
+            },
+            {
+                "role": "assistant",
+                "content": "Generate a concise and meaningful title for a GitHub pull request based on the provided git diff."
+            }
+        ]);
+
+        let title = self.generate_text(messages)?;
+
+        let final_message = if let Some(prefix) = prefix {
+            format!("{} {}", prefix, title.trim())
+        } else {
+            title.trim().to_string()
+        };
+
+        Ok(final_message)
+    }
+    fn generate_pr_description(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        let messages = json!([
+            {
+                "role": "system",
+                "content": "You are a helpful assistant specialized in writing detailed GitHub pull request descriptions."
+            },
+            {
+                "role": "user",
+                "content": format!("Here is a git diff:\n\n{}", diff)
+            },
+            {
+                "role": "assistant",
+                "content": "Generate a detailed and meaningful description for a GitHub pull request based on the provided git diff."
+            }
+        ]);
+
+        let description = self.generate_text(messages)?;
+
+        Ok(description.trim().to_string())
     }
 }
 
@@ -42,34 +127,7 @@ impl CommitMessageGenerator for OpenAIClient {
             }
         ]);
 
-        let response = self
-            .client
-            .post("https://api.openai.com/v1/chat/completions")
-            .bearer_auth(&self.api_key)
-            .json(&json!({
-                "model": &self.model,
-                "messages": messages,
-                "max_tokens": 60,
-            }))
-            .send()?;
-
-        let response_json: serde_json::Value = response.json()?;
-
-        let message = response_json
-            .get("choices")
-            .and_then(|choices| choices.get(0))
-            .and_then(|choice| choice.get("message"))
-            .and_then(|content| content.get("content"))
-            .and_then(|text| text.as_str())
-            .ok_or_else(|| {
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Failed to generate commit message. Unexpected response format: {}",
-                        response_json
-                    ),
-                )) as Box<dyn Error>
-            })?;
+        let message = self.generate_text(messages)?;
 
         let final_message = if let Some(prefix) = prefix {
             format!("{} {}", prefix, message.trim())


### PR DESCRIPTION
### Pull Request Description

#### Overview
This pull request updates the `gcmgen` crate version from `0.1.0` to `1.1.0` and introduces functionality for generating GitHub pull requests as well as improvements to the existing commit message generation features.

#### Changes Made
1. **Version Update**:
   - Updated the version of the `gcmgen` crate in both `Cargo.toml` and `Cargo.lock` from `0.1.0` to `1.1.0`.

2. **Anthropic Client Modifications**:
   - Added `PullRequestGenerator` trait implementation to enable generating pull request titles and descriptions.
   - Introduced a new method `generate_message` to streamline the process of sending messages to the Anthropic API.

3. **OpenAI Client Modifications**:
   - Added implementation for the `PullRequestGenerator` trait, including methods to generate pull request titles and descriptions based on the provided diff.

4. **Command Line Interface Enhancements**:
   - Added a new CLI argument `--pr` to allow users to create a pull request directly via the command line, invoking the new functionality for generating titles and descriptions.

5. **Pull Request Creation Logic**:
   - Implemented functionality to obtain the branch diff and prompt the user to accept, regenerate, or cancel the pull request creation.

6. **Git Utility Functions**:
   - Introduced `get_branch_diff` function to obtain differences against a specific branch, defaulting to `main`.

7. **General Code Improvements**:
   - Enhanced error handling and improved structuring of message generation for better maintainability and readability.

This pull request significantly enhances the capabilities of the `gcmgen` tool by integrating a smoother experience for generating and managing pull requests, while maintaining existing commit message functionalities.