### PR TITLE
Improve user input options for PR and commit actions in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Generated PR Description:\n{}\n", description);
 
             // Ask the user what they want to do
-            print!("Do you want to (a)ccept, (r)egenerate, or (c)ancel? [a/e/c]: ");
+            print!("Do you want to (y/a)ccept, (r)egenerate, or (q)uit? [(y|a)/e/q]: ");
             io::stdout().flush()?;
 
             let mut input = String::new();
@@ -129,7 +129,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let input = input.trim().to_lowercase();
 
             match input.as_str() {
-                "a" | "A" => {
+                "a" | "A" | "y" | "Y" => {
                     // Open the PR in the web browser with the title and description
                     create_pull_request(&title, &description, Some("main"))?;
                     println!("Pull request created successfully.");
@@ -138,14 +138,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "r" | "R" => {
                     println!("Regenerating commit message...");
                 }
-                "c" => {
+                "q" => {
                     // Cancel the PR creation process
                     println!("PR creation canceled.");
                     return Ok(());
                 }
                 _ => {
                     // Invalid input, ask again
-                    println!("Invalid option. Please choose 'a' to accept, 'e' to edit, or 'c' to cancel.");
+                    println!("Invalid option. Please choose 'a' to accept, 'r' to generate , or 'q' to cancel.");
                 }
             }
         }
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("\nGenerated commit message:\n\n{}\n", commit_message);
 
         // Ask the user what they want to do
-        print!("Do you want to (a)ccept, (e)dit, (r)egenerate, or (q)uit? If you quit, nothing will be committed [a/r/q]: ");
+        print!("Do you want to (y/a)ccept, (e)dit, (r)egenerate, or (q)uit? If you quit, nothing will be committed [(y|a)/r/q]: ");
         io::stdout().flush()?;
 
         let mut input = String::new();
@@ -179,7 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input = input.trim().to_lowercase();
 
         match input.as_str() {
-            "a" | "A" => {
+            "a" | "A" | "y" | "Y" => {
                 // Accept the commit message and commit the changes
                 git::commit(&commit_message)?;
                 println!("Committed with message: {}", commit_message);


### PR DESCRIPTION
### Pull Request Description

**Changes Made:**
1. **User Input Options Update**:
   - Updated the prompt for user actions related to pull request creation from:
     ```
     "Do you want to (a)ccept, (r)egenerate, or (c)ancel? [a/e/c]: "
     ```
     to 
     ```
     "Do you want to (y/a)ccept, (r)egenerate, or (q)uit? [(y|a)/e/q]: "
     ```
   - Updated the logic for handling input to allow both 'a'/'A' and 'y'/'Y' as acceptable options for accepting the pull request.

2. **Cancellation Option Update**:
   - Changed the cancellation option from 'c' to 'q':
     - From:
       ```
       "Invalid option. Please choose 'a' to accept, 'e' to edit, or 'c' to cancel."
       ```
       to
       ```
       "Invalid option. Please choose 'a' to accept, 'r' to regenerate, or 'q' to cancel."
       ```

3. **Commit Message Workflow Update**:
   - Updated the prompt when asking for commitment actions to reflect the new options:
     ```
     "Do you want to (y/a)ccept, (e)dit, (r)egenerate, or (q)uit? If you quit, nothing will be committed [(y|a)/r/q]: "
     ```
   - Similar to the pull request option, the acceptable options for commit acceptance were expanded to include both 'a'/'A' and 'y'/'Y'.

These updates enhance user experience by providing clearer options and improving the flexibility of accepted input for both pull request creation and commit handling.